### PR TITLE
cscopes: set initOrder for ScopedContactsProvider

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -43,6 +43,7 @@
         android:usesCleartextTraffic="false">
 
         <provider android:name="ContactsProvider2"
+            android:initOrder="100"
             android:authorities="contacts;com.android.contacts"
             android:label="@string/provider_label"
             android:multiprocess="false"
@@ -136,6 +137,7 @@
 
         <provider
             android:name=".ScopedContactsProvider"
+            android:initOrder="1"
             android:authorities="com.android.contacts.scoped"
             android:exported="true"/>
 


### PR DESCRIPTION
ScopedContactsProvider depends on ContactsProvider2. In some cases, ScopedContactsProvider initialization was attempted before ContactsProvider2 initialization, which led to a crash.

Providers with higher initOrder value are initialized first.