### PR TITLE
allow user to set any account as the default contacts account

### DIFF
--- a/src/com/android/providers/contacts/DefaultAccountManager.java
+++ b/src/com/android/providers/contacts/DefaultAccountManager.java
@@ -68,19 +68,6 @@ public class DefaultAccountManager {
         mAccountAttributesManager = accountAttributesManager;
     }
 
-    private static synchronized Set<String> getPreconfiguredSystemAccountTypes(Context context) {
-        if (sEligibleSystemCloudAccountTypes == null) {
-            sEligibleSystemCloudAccountTypes = new HashSet<>();
-
-            Resources resources = Resources.getSystem();
-            String[] accountTypesArray =
-                    resources.getStringArray(R.array.config_rawContactsEligibleDefaultAccountTypes);
-
-            sEligibleSystemCloudAccountTypes.addAll(Arrays.asList(accountTypesArray));
-        }
-        return sEligibleSystemCloudAccountTypes;
-    }
-
     @NeededForTesting
     static synchronized void setEligibleSystemCloudAccountTypesForTesting(String[] accountTypes) {
         sEligibleSystemCloudAccountTypes = new HashSet<>(Arrays.asList(accountTypes));
@@ -208,12 +195,7 @@ public class DefaultAccountManager {
     }
 
     private boolean isEligibleSystemCloudAccount(Account account, Account[] systemAccounts) {
-        if (account == null) {
-            return false;
-        }
-
-        return getPreconfiguredSystemAccountTypes(mContext).contains(account.type)
-                || isEligibleCloudAccountByAttributes(account, systemAccounts);
+        return account != null;
     }
 
     private boolean isEligibleCloudAccountByAttributes(Account account, Account[] systemAccounts) {


### PR DESCRIPTION
Since 16 QPR1, AOSP requires contacts account to be part of config_rawContactsEligibleDefaultAccountTypes array in order to be set as the default contacts account.

That config is empty on AOSP (i.e. user is not allowed to select a default contacts account). On stock Pixel OS, it's set to "com.google" (i.e. only a Google account can be set as default).

Closes: https://github.com/GrapheneOS/os-issue-tracker/issues/6613