### PR TITLE
cscopes: add missing handling for _count queries when scopes are empty

### DIFF
--- a/src/com/android/providers/contacts/ScopedContactsProvider.java
+++ b/src/com/android/providers/contacts/ScopedContactsProvider.java
@@ -81,6 +81,11 @@ public class ScopedContactsProvider extends RedirectedContentProvider {
         checkAccess(callerPackageState);
 
         if (ContactScopesStorage.isEmpty(callerPackageState)) {
+            if (projection != null && projection.length == 1 && BaseColumns._COUNT.equals(projection[0])) {
+                var res = new MatrixCursor(projection, 1);
+                res.addRow(new Object[] { Integer.valueOf(0) });
+                return res;
+            }
             return ContactsProvider2.createEmptyCursor(uri, projection, false);
         }
 


### PR DESCRIPTION
Closes: https://github.com/GrapheneOS/os-issue-tracker/issues/7249